### PR TITLE
fix: Enforce Correct Storage Bucket

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -10,7 +10,8 @@ const firebaseConfig = {
     apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
     authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
     projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
-    storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
+    // explicit fix: force the correct storage bucket url
+    storageBucket: "sand-gallery-lab.firebasestorage.app",
     messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
     appId: import.meta.env.VITE_FIREBASE_APP_ID,
     measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID


### PR DESCRIPTION
The frontend was targeting a legacy/alias bucket domain. This PR forces connection to 'sand-gallery-lab.firebasestorage.app' where CORS is correctly configured.